### PR TITLE
Node: name native library as libsignal_client_PLATFORM.node

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -4,9 +4,14 @@
 #
 
 {
+    'conditions': [
+        ['OS=="mac"', {'variables': {'NODE_OS_NAME': 'darwin'}},
+         'OS=="win"', {'variables': {'NODE_OS_NAME': 'win32'}},
+         {'variables': {'NODE_OS_NAME': '<(OS)'}}],
+    ],
     'targets': [
         {
-            'target_name': 'libsignal_client.node',
+            'target_name': 'libsignal_client_<(NODE_OS_NAME).node',
             'type': 'none',
             'actions': [
                 {
@@ -15,11 +20,12 @@
                         'env',
                         'CONFIGURATION_NAME=<(CONFIGURATION_NAME)',
                         'CARGO_BUILD_TARGET_DIR=<(INTERMEDIATE_DIR)/rust',
+                        'NODE_OS_NAME=<(NODE_OS_NAME)',
                         'node/build_node_bridge.sh',
                         '-o', '<(PRODUCT_DIR)/'],
                     'inputs': [],
                     'outputs': [
-                        '<(PRODUCT_DIR)/libsignal_client.node',
+                        '<(PRODUCT_DIR)/<(_target_name)',
                         # This really needs to be environment-variable-sensitive, but node-gyp doesn't support that. Cargo will still save work if possible.
                         '<(PRODUCT_DIR)/nonexistent-file-to-force-rebuild'
                     ]

--- a/node/build_node_bridge.sh
+++ b/node/build_node_bridge.sh
@@ -18,6 +18,8 @@ Usage: $(basename "$0") [-d] [-o DIR/]
 Options:
 	-d -- debug build (default is release, follows \$CONFIGURATION_NAME)
 	-o -- where to copy the built module (default: build/\$CONFIGURATION_NAME)
+
+NODE_OS_NAME must also be set to the value of Node's \`os.platform()\`.
 END
 }
 
@@ -57,10 +59,16 @@ case ${CONFIGURATION_NAME} in
     exit 1
 esac
 
+if [[ -z "${NODE_OS_NAME:-}" ]]; then
+  echo 'error: NODE_OS_NAME not set' >&2
+  echo "note: run through \`yarn install\` to populate this automatically" >&2
+  exit 1
+fi
+
 OUT_DIR=${OUT_DIR:-build/${CONFIGURATION_NAME}}
 
 check_rust
 
 echo_then_run cargo build -p libsignal-node ${CARGO_PROFILE_ARG}
 
-copy_built_library "${CARGO_BUILD_TARGET_DIR:-target}/${CARGO_BUILD_TARGET:-}/${CARGO_PROFILE_DIR}" signal_node "${OUT_DIR}"/libsignal_client.node
+copy_built_library "${CARGO_BUILD_TARGET_DIR:-target}/${CARGO_BUILD_TARGET:-}/${CARGO_PROFILE_DIR}" signal_node "${OUT_DIR}"/libsignal_client_"${NODE_OS_NAME}".node

--- a/node/index.ts
+++ b/node/index.ts
@@ -3,10 +3,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import * as os from 'os';
 import bindings = require('bindings'); // eslint-disable-line @typescript-eslint/no-require-imports
 import * as SignalClient from './libsignal_client';
 
-const SC = bindings('libsignal_client') as typeof SignalClient;
+const SC = bindings('libsignal_client_' + os.platform()) as typeof SignalClient;
 
 export class PublicKey {
   private readonly nativeHandle: SignalClient.PublicKey;


### PR DESCRIPTION
This makes it easier to have a combined artifact root for all
supported platforms.